### PR TITLE
Make `WellSql.mapperFor` public so users can call it to create custom mappers

### DIFF
--- a/wellsql/src/main/java/com/yarolegovich/wellsql/WellSql.java
+++ b/wellsql/src/main/java/com/yarolegovich/wellsql/WellSql.java
@@ -89,7 +89,7 @@ public class WellSql extends SQLiteOpenHelper {
         return sInstance.getWritableDatabase();
     }
 
-    static <T> SQLiteMapper<T> mapperFor(Class<T> token) {
+    public static <T> SQLiteMapper<T> mapperFor(Class<T> token) {
         SQLiteMapper<T> mapper = mDbConfig.getMapper(token);
         if (mapper == null) {
             throw new RuntimeException(mDbConfig.getContext()


### PR DESCRIPTION
Make `WellSql.mapperFor` public so users can call it to create custom mappers