### PR TITLE
New ConditionClauseBuilder.equals method for boolean values

### DIFF
--- a/well-sample/src/androidTest/java/com/yarolegovich/wellsample/WellSqlTest.java
+++ b/well-sample/src/androidTest/java/com/yarolegovich/wellsample/WellSqlTest.java
@@ -196,6 +196,18 @@ public class WellSqlTest {
         assertEquals(getHeroes().size(), counter);
     }
 
+    @Test
+    public void selectBooleanConditionWorks() {
+        List<SuperHero> heroes = getHeroes();
+        heroes.get(3).setIsTrueEvil(true);
+        heroes.get(5).setIsTrueEvil(true);
+        WellSql.insert(heroes).execute();
+        int evilHeroes = WellSql.select(SuperHero.class)
+                .where().equals(SuperHeroTable.IS_TRUE_EVIL, true).endWhere()
+                .getAsCursor().getCount();
+        assertEquals(2, evilHeroes);
+    }
+
     private List<SuperHero> getHeroes() {
         return Arrays.asList(
                 new SuperHero("Hank Pym", 1),

--- a/wellsql/src/main/java/com/yarolegovich/wellsql/ConditionClauseBuilder.java
+++ b/wellsql/src/main/java/com/yarolegovich/wellsql/ConditionClauseBuilder.java
@@ -125,6 +125,10 @@ public class ConditionClauseBuilder<T extends ConditionClauseConsumer> {
         return this;
     }
 
+    public ConditionClauseBuilder<T> equals(String column, boolean value) {
+        return equals(column, value ? 1 : 0);
+    }
+
     public ConditionClauseBuilder<T> or() {
         mSelectionBuilder.append(" OR ");
         return this;


### PR DESCRIPTION
SQLite doesn't support `true` / `false` in where clause, so use `1` / `0` instead.